### PR TITLE
Fix desyncs

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -73,7 +73,7 @@ def parse_tasbot(replay_file):
     '''
     
     replay = json.loads(replay_file)
-    replay_fps = round(int(replay['fps']))
+    replay_fps = int(round(replay['fps']))
     replay_data = replay['macro']
     last_click_action = False
     last_p2_click_action = False

--- a/parser.py
+++ b/parser.py
@@ -10,7 +10,7 @@ def parse_echo(replay_file):
     '''
 
     replay = json.loads(replay_file)
-    replay_fps = round(int(replay['FPS']))
+    replay_fps = int(round(replay['FPS']))
     replay_data = replay['Echo Replay']
     last_click_action = False
     last_p2_click_action = False


### PR DESCRIPTION
Your current system always rounds the framerate down.
When I have a replay, often it has an FPS of 143.999999997 or something like that.
In the parser module, it does int() before round(), and int() always floors the number.
This means 143.999999997 becomes 143, not 144.

This is not much of an issue, however after a while clicks become desynced.
What I have done is I have reversed the order of the functions, causing it to properly round.

Enjoy!